### PR TITLE
export generate function to update at runtime

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 /test
-/src
 /datasets-extended

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ npm run generate
 
 For Spain and France, data directly from the European Central Bank is used, see [here](https://www.ecb.europa.eu/stats/financial_corporations/list_of_financial_institutions/html/monthly_list-MID.en.html).
 
+### programmatically update the dataset
+
+You can also update the dataset at runtime whenever you want (e.g. at start-up):
+
+```
+const { ibanToBic, generate } = require('iban-to-bic');
+
+await generate();
+
+```
+
+
 ## License
 
 MIT

--- a/datasets/index.js
+++ b/datasets/index.js
@@ -18,12 +18,12 @@ module.exports =
     return dataset[country][bankCode];
   },
   reload: async () => {
-    dataset.AT = JSON.parse(await readFile(`./datasets/at.json`, 'utf8'));
-    dataset.BE = JSON.parse(await readFile(`./datasets/be.json`, 'utf8'));
-    dataset.DE = JSON.parse(await readFile(`./datasets/de.json`, 'utf8'));
-    dataset.ES = JSON.parse(await readFile(`./datasets/es.json`, 'utf8'));
-    dataset.FR = JSON.parse(await readFile(`./datasets/fr.json`, 'utf8'));
-    dataset.LU = JSON.parse(await readFile(`./datasets/lu.json`, 'utf8'));
-    dataset.NL = JSON.parse(await readFile(`./datasets/nl.json`, 'utf8'));
+    dataset.AT = JSON.parse(await readFile(path.resolve(__dirname, './at.json'), 'utf8'));
+    dataset.BE = JSON.parse(await readFile(path.resolve(__dirname, './be.json'), 'utf8'));
+    dataset.DE = JSON.parse(await readFile(path.resolve(__dirname, './de.json'), 'utf8'));
+    dataset.ES = JSON.parse(await readFile(path.resolve(__dirname, './es.json'), 'utf8'));
+    dataset.FR = JSON.parse(await readFile(path.resolve(__dirname, './fr.json'), 'utf8'));
+    dataset.LU = JSON.parse(await readFile(path.resolve(__dirname, './lu.json'), 'utf8'));
+    dataset.NL = JSON.parse(await readFile(path.resolve(__dirname, './nl.json'), 'utf8'));
   }
 }

--- a/datasets/index.js
+++ b/datasets/index.js
@@ -1,4 +1,5 @@
-module.exports = {
+const { readFile } = require('fs/promises');
+const dataset = {
   AT: require('./at.json'),
   BE: require('./be.json'),
   DE: require('./de.json'),
@@ -7,3 +8,22 @@ module.exports = {
   LU: require('./lu.json'),
   NL: require('./nl.json'),
 };
+
+module.exports = 
+{
+  hasCountry(country) {
+    return dataset[country] !== undefined;
+  },
+  getData(country, bankCode) {
+    return dataset[country][bankCode];
+  },
+  reload: async () => {
+    dataset.AT = JSON.parse(await readFile(`./datasets/at.json`, 'utf8'));
+    dataset.BE = JSON.parse(await readFile(`./datasets/be.json`, 'utf8'));
+    dataset.DE = JSON.parse(await readFile(`./datasets/de.json`, 'utf8'));
+    dataset.ES = JSON.parse(await readFile(`./datasets/es.json`, 'utf8'));
+    dataset.FR = JSON.parse(await readFile(`./datasets/fr.json`, 'utf8'));
+    dataset.LU = JSON.parse(await readFile(`./datasets/lu.json`, 'utf8'));
+    dataset.NL = JSON.parse(await readFile(`./datasets/nl.json`, 'utf8'));
+  }
+}

--- a/datasets/index.js
+++ b/datasets/index.js
@@ -1,4 +1,6 @@
 const { readFile } = require('fs/promises');
+const path = require('path');
+
 const dataset = {
   AT: require('./at.json'),
   BE: require('./be.json'),

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const ibantools = require('ibantools');
 const datasets = require('./datasets');
+const generateFiles = require('./src/generate');
 
 module.exports = {
   ibanIsValid(iban) {
@@ -11,7 +12,7 @@ module.exports = {
     if (!ibantools.isValidIBAN(iban)) return;
 
     const country = iban.slice(0, 2);
-    if (!datasets[country]) return;
+    if (!datasets.hasCountry(country)) return;
 
     // see https://en.wikipedia.org/wiki/International_Bank_Account_Number#IBAN_formats_by_country
     let bankCode;
@@ -24,6 +25,10 @@ module.exports = {
     else if (country === 'NL') bankCode = iban.substr(4, 4);
     if (!bankCode) return;
 
-    return datasets[country][bankCode];
+    return datasets.getData(country, bankCode);
   },
+  async generate() {
+    await generateFiles();
+    await datasets.reload();
+  }
 };

--- a/package.json
+++ b/package.json
@@ -25,17 +25,17 @@
   },
   "homepage": "https://github.com/sigalor/iban-to-bic#readme",
   "dependencies": {
-    "ibantools": "^4.2.2"
-  },
-  "devDependencies": {
+    "ibantools": "^4.2.2",
     "fs-extra": "^11.1.0",
     "iconv-lite": "^0.6.3",
-    "jest": "^29.3.1",
     "jsdom": "^21.0.0",
     "neat-csv": "^6.0.1",
     "node-fetch-commonjs": "^3.2.4",
-    "webpack": "^5.75.0",
-    "webpack-cli": "^5.0.1",
     "xlsx": "^0.18.5"
+  },
+  "devDependencies": {
+    "jest": "^29.3.1",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
   }
 }

--- a/src/generate.js
+++ b/src/generate.js
@@ -5,6 +5,14 @@ const frEs = require('./fr-es');
 const lu = require('./lu');
 const nl = require('./nl');
 
-(async () => {
-  await Promise.all([at(), be(), de(), frEs(), lu(), nl()]);
-})();
+async function generate() {
+  return Promise.all([at(), be(), de(), frEs(), lu(), nl()]);
+}
+
+if (module.parent) {
+  module.exports = generate;
+} else {
+  (async () => {
+    await generate();
+  })();
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,8 +23,9 @@ function getCellValue(worksheet, col, row) {
 }
 
 async function writeOutputs(name, bankCodesObj) {
-  await fs.writeJSON(path.join(__dirname, `../datasets-extended/${name}.json`), bankCodesObj);
-
+  if (fs.existsSync(path.join(__dirname, `../datasets-extended`))) {
+    await fs.writeJSON(path.join(__dirname, `../datasets-extended/${name}.json`), bankCodesObj);
+  }
   const bankCodesToBic = Object.entries(bankCodesObj).reduce((prev, [code, { bic, branches }]) => {
     if (bic) prev[code] = bic;
     else if (branches && branches[0] && branches[0].bic) prev[code] = branches[0].bic;


### PR DESCRIPTION
This PR exports the generate function and has some internal changes to allow for updating the datasources at runtime:

```js
const { ibanToBic, generate } = require('iban-to-bic');
await generate();
```

This way it is possible to update the datasources at any time (at startup, once a month, …), without having to update the module.
No API changes, I just added the `generate` function to the exported module. 
It is still possible to run the generate script directly.